### PR TITLE
Refactor to share Authenticator instance

### DIFF
--- a/LEO_sniffy/firmwaremanager.cpp
+++ b/LEO_sniffy/firmwaremanager.cpp
@@ -6,7 +6,7 @@
 #include <QJsonObject>
 #include <QUrlQuery>
 
-FirmwareManager::FirmwareManager(QObject *parent) : QObject(parent),
+FirmwareManager::FirmwareManager(Authenticator *auth, QObject *parent) : QObject(parent),
                                                     m_flashInProgress(false)
 {
     // Initialize Flasher
@@ -24,7 +24,7 @@ FirmwareManager::FirmwareManager(QObject *parent) : QObject(parent),
     connect(m_flasher, &StLinkFlasher::deviceUIDError, this, &FirmwareManager::onDeviceUIDError);
 
     // Authenticator for remote flow
-    m_auth = new Authenticator(this);
+    m_auth = auth;
     connect(m_auth, &Authenticator::requestStarted, this, &FirmwareManager::onAuthStarted);
     connect(m_auth, &Authenticator::requestFinished, this, &FirmwareManager::onAuthFinished);
     connect(m_auth, &Authenticator::authenticationFailed, this, &FirmwareManager::onAuthFailed);

--- a/LEO_sniffy/firmwaremanager.h
+++ b/LEO_sniffy/firmwaremanager.h
@@ -18,7 +18,7 @@ class FirmwareManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit FirmwareManager(QObject *parent = nullptr);
+    explicit FirmwareManager(Authenticator *auth, QObject *parent = nullptr);
     ~FirmwareManager();
 
     enum StatusMessageType {

--- a/LEO_sniffy/mainwindow.cpp
+++ b/LEO_sniffy/mainwindow.cpp
@@ -49,12 +49,13 @@ MainWindow::MainWindow(QWidget *parent):
                                      "QWidget#centralwidget{border-right: 1px solid"+pal.textLabel+";}");
 
     setWindowTitle("LEO sniffy");
-    sett = new SettingsDialog(this);
-    connect(sett, &SettingsDialog::saveSessionRequested, this, &MainWindow::onSettingsSaveSessionRequested);
-    connect(sett, &SettingsDialog::loadSessionRequested, this, &MainWindow::onSettingsLoadSessionRequested);
     
     // Create shared authenticator
     authenticator = new Authenticator(this);
+
+    sett = new SettingsDialog(authenticator, this);
+    connect(sett, &SettingsDialog::saveSessionRequested, this, &MainWindow::onSettingsSaveSessionRequested);
+    connect(sett, &SettingsDialog::loadSessionRequested, this, &MainWindow::onSettingsLoadSessionRequested);
     
     logindial = new LoginDialog(authenticator, this);
     connect(logindial, &LoginDialog::loginInfoChangedReopen, sett, &SettingsDialog::onUserLoginChanged);

--- a/LEO_sniffy/settingsdialog.cpp
+++ b/LEO_sniffy/settingsdialog.cpp
@@ -3,7 +3,7 @@
 #include <QStandardPaths>
 #include <QScrollBar>
 
-SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent),
+SettingsDialog::SettingsDialog(Authenticator *auth, QWidget *parent) : QDialog(parent),
                                                   ui(new Ui::SettingsDialog)
 {
     ui->setupUi(this);
@@ -85,7 +85,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent),
     buttons->addWidget(flashLogWindow);
 
     // Initialize Firmware Manager
-    m_firmwareManager = new FirmwareManager(this);
+    m_firmwareManager = new FirmwareManager(auth, this);
     
     connect(buttonsFlash, &WidgetButtons::clicked, this, &SettingsDialog::onFlashButtonClicked);
     

--- a/LEO_sniffy/settingsdialog.h
+++ b/LEO_sniffy/settingsdialog.h
@@ -25,7 +25,7 @@ class SettingsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit SettingsDialog(QWidget *parent = nullptr);
+    explicit SettingsDialog(Authenticator *auth, QWidget *parent = nullptr);
     ~SettingsDialog();
     void open();
 


### PR DESCRIPTION
SettingsDialog and FirmwareManager now accept an Authenticator instance via their constructors, allowing MainWindow to provide a shared Authenticator. This improves resource management and ensures consistent authentication state across dialogs.